### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ If you would like to specify where to save the ouptut, simply use the ``-o`` or 
     $ metapredict-predict-pLDDT /Users/thisUser/Desktop/interestingProteins.fasta -o /Users/thisUser/Desktop/disorder_predictions/my_pLDDT_predictions.csv
 
 
-### Graphing Disorder form a fasta file
+### Graphing Disorder from a fasta file
 
 The ``metapredict-graph-disorder`` command from the command line takes a .fasta file as input and returns a graph for every sequence within the .fasta file. **Warning** This will return a graph for every sequence in the FASTA file. 
 
@@ -169,7 +169,7 @@ If you would like to change the disorder threshold line plotted on the graph, us
     $ metapredict-graph-disorder /Users/thisUser/Desktop/interestingProteins.fasta -o /Users/thisUser/Desktop/DisorderGraphsFolder/ --disorder-threshold 0.5
 
 
-### Graphing Disorder form a sequence
+### Graphing Disorder from a sequence
 
 ``metapredict-quick-graph`` is a command that will let you input a sequence and get a plot of the disorder back immediately. You cannot input fasta files for this command. The command only takes three arguments, 1. the sequence 2. *optional* DPI ``-D``  or ``--dpi`` of the ouput graph which defaults to 150 DPI, and 3. *optional* to include predicted AlphaFold2 condience scores, use the ``-p`` or ``--pLDDT`` flag.
 
@@ -186,7 +186,7 @@ If you would like to change the disorder threshold line plotted on the graph, us
 
 	$ metapredict-quick-graph ISQQMQAQPAMVKSQQQQQQQQQQHQHQQQQLQQQQQLQMSQQQVQQQGIYNNGTIAVAN -D 200 -p
 
-### Graphing Disorder form a Uniprot ID
+### Graphing Disorder from a Uniprot ID
 
 ``metapredict-uniprot`` is a command that will let you input any Uniprot ID and get a plot of the disorder for the corresponding protein. The default behavior is to have a plot automatically appear. Apart from the Uniprot ID which is required for this command, the command has four possible additional *optional* arguments, 1. To include predicted AlphaFold2 2 pLDDT confidence scores, use the ``-p``  or ``--pLDDT`` flag. DPI can be changed with the ``-D``  or ``--dpi`` flags, default is 150 DPI, 3. Using ``-o``  or ``--ourput-file`` will save the plot to a specified directory (default is current directory) - filenames and file extensions (pdf, jpg, png, etc) can be specified here. If there is no file name specified, it will save as the Uniprot ID and as a .png, 4. ``-t``  or ``--title`` will let you specify the title of the plot. By defualt the title will be *Disorder for* followed by the Uniprot ID.
 


### PR DESCRIPTION
In the current README, there are multiple occurences of `form` instead of `from`. This PR fixes these typos.